### PR TITLE
Fix typo in hostname check for local environment

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -90,7 +90,7 @@ export default {
 
             map.U.addVector(
                 'trees',
-                window.location.hostname === 'localhoost'
+                window.location.hostname === 'localhost'
                     ? 'http://localhost:4011/index.json'
                     : 'mapbox://stevage.9slh6b3l'
             );


### PR DESCRIPTION
localhoost -> localhost
was preventing me from viewing local tiles.

Related to #79 